### PR TITLE
Correct typos in "News" section

### DIFF
--- a/content/newslist.dat
+++ b/content/newslist.dat
@@ -4,9 +4,9 @@
 
 **[02/2025]** Caesar was accepted to the UW ECE PhD program and will start this fall, continuing his research in Echospace! Congratulations, Caesar!
 
-**[10/2025]** [Ameena Majeed](/author/ameena-majeed) joied Echospace as an Undergrad Research Assistant. Welcome!
+**[10/2025]** [Ameena Majeed](/author/ameena-majeed) joined Echospace as an Undergrad Research Assistant. Welcome!
 
-**[08/2025]** [Aidan Lee](/author/aidan-lee) joied Echospace as an Undergrad Research Assistant. Welcome!
+**[08/2025]** [Aidan Lee](/author/aidan-lee) joined Echospace as an Undergrad Research Assistant. Welcome!
 
 **[07/2024]** Wu-Jung gave a talk on our [Echostack software suite](https://proceedings.scipy.org/articles/WXRH8633) and Valentina presented a poster on the [Echodataflow package](https://proceedings.scipy.org/articles/JXDK4427) at the Scipy 2024 conference.
 
@@ -75,3 +75,4 @@
 **[10/2021]** Wu-Jung gave the UW Data Science Seminar on ["Building a toolbox for studying marine ecology using large ocean sonar datasets"](/talk/202110-uw-data-sci).
 
 **[09/2021]** Wu-Jung and Linda successfully completed this summer's fieldwork evaluating the use of an ADCP-equipped glider as a biological monitoring tool. Check out [NOAA Exploration's coverage of this mission](https://oceanexplorer.noaa.gov/technology/development-partnerships/21adcp-gliders/welcome.html)!
+


### PR DESCRIPTION
There were a couple of instances  in the News/Recent News section where it said "joied" so I changed them to "joined."